### PR TITLE
Fix picker openning function

### DIFF
--- a/src/Filestack.vue
+++ b/src/Filestack.vue
@@ -84,7 +84,7 @@ export default {
         return client.remove(handle, security)
       }
 
-      return client.pick(ops)
+      return client.picker(ops).open()
     }
   }
 }


### PR DESCRIPTION
The component wasn't working because of the client.pick() function, in fact, it crashed the entire application. I fixed it to work with the new version of filestack.